### PR TITLE
Added a patchlog page

### DIFF
--- a/PatchLog.html
+++ b/PatchLog.html
@@ -32,6 +32,23 @@
                 }
             });
         </script>
+                <!-- Footer -->
+                <footer class="footer">
+                    <h3 class="footer__title">Projects</h3>
+                    <div class="footer__list">
+                        <li class="footer__list__item"><a class="footer__list__item__link" target="_blank" href="https://github.com/Omega-Numworks/Omega">Omega</a></li>
+                        <li class="footer__list__item"><a class="footer__list__item__link" target="_blank" href="https://github.com/Omega-Numworks/Omega-Themes">Omega Themes</a></li>
+                        <li class="footer__list__item"><a class="footer__list__item__link" target="_blank" href="https://github.com/Omega-Numworks/Omega-Website">Omega Website</a></li>
+                        <li class="footer__list__item"><a class="footer__list__item__link" target="_blank" href="https://github.com/Omega-Numworks/Omega-CLI-Installer">Omega CLI Installer</a></li>
+                        <li class="footer__list__item"><a class="footer__list__item__link" target="_blank" href="https://github.com/Omega-Numworks/Omega-RPN">Omega RPN <span class="footer__list__item__tag">APP</span></a></li>
+                        <li class="footer__list__item"><a class="footer__list__item__link" target="_blank" href="https://github.com/Omega-Numworks/Omega-Atom">Omega Atom <span class="footer__list__item__tag">APP</span></a></li>
+                        <li class="footer__list__item"><a class="footer__list__item__link" target="_blank" href="https://github.com/Omega-Numworks/Omega-Design">Omega Design</a></li>
+                        <li class="footer__list__item"><a class="footer__list__item__link" target="_blank" href="https://github.com/Omega-Numworks/Omega-WEB-Installer">Omega WEB Installer <span class="footer__list__item__tag">DEPRECATED</span></a></li>
+                    </div>
+                    <div class="footer__separator" />
+                    <div class="footer__logo">Omega</div>
+                    <div class="footer__about-nw">NumWorks is a registered trademark. Omega is not affiliated with Numworks.</div>
+                </footer>
         <script src="js/bootstrap.bundle.min.js"></script>
     </body>
 </html>

--- a/PatchLog.html
+++ b/PatchLog.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="ie=edge">
+        <title>Patchlog - </title>
+        <script src="https://unpkg.com/showdown/dist/showdown.min.js"></script>
+        <script src="js/jquery-3.4.1.min.js"></script>
+        <link rel="stylesheet" href="css/bootstrap.min.css">
+        <link rel="stylesheet" href="css/style.css">
+        <link rel="stylesheet" href="css/omega.library.css">
+    </head>
+    <body>
+        <!-- Header -->
+        <header class="header">
+           <a class="header__logo" href="index.html">Omega</a>
+            <div class="header__links">
+                <a class="header__links__link" href="install.html">Install</a>
+                <a class="header__links__link" href="PatchLog.html">Patchlog</a>
+                <a class="header__links__link" href="https://github.com/Omega-Numworks/Omega" target="_blank">Github</a>
+            </div>
+        </header>
+        <div id="markdown"></div>
+        <script>
+            var converter = new showdown.Converter();
+            $.ajax({
+                url:"PatchLog.md",
+                method: 'GET',
+                success : (data) => {
+                    document.getElementById("markdown").insertAdjacentHTML("afterbegin", converter.makeHtml(data))
+                }
+            });
+        </script>
+        <script src="js/bootstrap.bundle.min.js"></script>
+    </body>
+</html>

--- a/PatchLog.html
+++ b/PatchLog.html
@@ -21,14 +21,29 @@
                 <a class="header__links__link" href="https://github.com/Omega-Numworks/Omega" target="_blank">Github</a>
             </div>
         </header>
-        <div id="markdown"></div>
+        <div id="PatchLog"><h1>Loading patchlog</h1></div>
+        <div id="PatchLogBar"></div>
+        <a href=""></a>
         <script>
             var converter = new showdown.Converter();
+            var PatchLog = document.getElementById("PatchLog");
+            var PatchLogBar = document.getElementById("PatchLogBar");
+            var ReferencedInBar = "H2";
             $.ajax({
                 url:"PatchLog.md",
                 method: 'GET',
                 success : (data) => {
-                    document.getElementById("markdown").insertAdjacentHTML("afterbegin", converter.makeHtml(data))
+                    html = converter.makeHtml(data);
+                    PatchLog.innerHTML = ""
+                    PatchLog.insertAdjacentHTML("afterbegin", html);
+                    var children = PatchLog.childNodes;
+                    for (var i = 0; i < children.length; i++) {
+                        if(children[i].nodeName == ReferencedInBar){
+                            console.log(children[i].innerText)
+                            children[i].id = children[i].innerText;
+                            PatchLogBar.innerHTML += '<a href="#' + children[i].innerText + '">' + children[i].innerText + "</a><br>";
+                        }
+                    }
                 }
             });
         </script>

--- a/PatchLog.md
+++ b/PatchLog.md
@@ -1,0 +1,4 @@
+## 1.18
+
+### Added atom
+![](img/atom.png)

--- a/PatchLog.md
+++ b/PatchLog.md
@@ -2,3 +2,11 @@
 
 ### Added atom
 ![](img/atom.png)
+
+## 1.17
+
+Blabla about the version
+
+## 1.16
+
+Angain blabla

--- a/css/style.css
+++ b/css/style.css
@@ -1,18 +1,3 @@
-@font-face {
-    font-family: "TitleFont";
-    src: url("fonts/TitleFont.ttf");
-}
-
-@font-face {
-    font-family: "LargeFont";
-    src: url("fonts/LargeFont.ttf");
-}
-
-@font-face {
-    font-family: "SmallFont";
-    src: url("fonts/SmallFont.ttf");
-}
-
 .navbar-brand {
     font: 2.2em TitleFont, sans-serif;
     color: #c53431 !important;

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
             <a class="header__logo" href="index.html">Omega</a>
             <div class="header__links">
                 <a class="header__links__link" href="install.html">Install</a>
+                <a class="header__links__link" href="PatchLog.html">Patchlog</a>
                 <a class="header__links__link" href="https://github.com/Omega-Numworks/Omega" target="_blank">Github</a>
             </div>
         </header>

--- a/install.html
+++ b/install.html
@@ -19,6 +19,7 @@
             <a class="header__logo" href="index.html">Omega</a>
             <div class="header__links">
                 <a class="header__links__link" href="install.html">Install</a>
+                <a class="header__links__link" href="PatchLog.html">Patchlog</a>
                 <a class="header__links__link" href="https://github.com/Omega-Numworks/Omega" target="_blank">Github</a>
             </div>
         </header>


### PR DESCRIPTION
I added a simple patchlog page.
I don't know very well css, so I'll let you change the style.

There are things to do :

- [x] add a GOTO bar

- [ ] add an intersection manager for higlighting the vresion shown in the bar

- [ ] complete the patchlog with things, like version, things added, contributors, image (I'll do it)

- [ ] add in https://github.com/Omega-Numworks/Omega-Website/blob/master/LICENSE.md https://github.com/showdownjs/showdown/blob/master/LICENSE

https://github.com/Omega-Numworks/Omega-Website/issues/3 can be closed

Image :
![image](https://user-images.githubusercontent.com/43498612/71558355-a872c480-2a52-11ea-9100-8090849bc59a.png)
The blue things are links


(Yes there's a issue with the theme)